### PR TITLE
Update dictionary build

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ The entries are structs of:
 ```go
 type DictionaryEntry struct {
   Headword          string
-  PartOfSpeech      string
+  PartOfSpeech      []string
   GrammaticalAspect string
+  Information       string
   Definitions       []string
   AlternativeForms  []string
 }

--- a/dictionary.go
+++ b/dictionary.go
@@ -8,10 +8,11 @@ import (
 
 type DictionaryEntry struct {
 	Headword          string   `json:"a"`
-	PartOfSpeech      string   `json:"b"`
+	PartOfSpeech      []string `json:"b"`
 	GrammaticalAspect string   `json:"c"`
-	Definitions       []string `json:"d"`
-	AlternativeForms  []string `json:"e"`
+	Information       string   `json:"d"`
+	Definitions       []string `json:"e"`
+	AlternativeForms  []string `json:"f"`
 }
 
 func parseDictionary(bytes []byte) ([]DictionaryEntry, error) {

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -16,9 +16,12 @@ func TestDictionaryHasExpectedEntries(t *testing.T) {
 	result, _ := GetDictionary()
 
 	expected1 := DictionaryEntry{
-		Headword:          "af bränna",
-		PartOfSpeech:      "vb",
+		Headword: "af bränna",
+		PartOfSpeech: []string{
+			"vb",
+		},
 		GrammaticalAspect: "v.",
+		Information:       "",
 		Definitions: []string{
 			"afbränna, genom eld förstöra. hans trähws the af brendhe  RK 2: 2757 . ib 1511. halff stadhen är affbrändh  BSH 5: 132 (  1506) . Jfr bränna af.",
 		},
@@ -26,11 +29,14 @@ func TestDictionaryHasExpectedEntries(t *testing.T) {
 	}
 
 	expected2 := DictionaryEntry{
-		Headword:          "alder daghar",
-		PartOfSpeech:      "nn",
+		Headword: "alder daghar",
+		PartOfSpeech: []string{
+			"nn",
+		},
 		GrammaticalAspect: "pl.",
+		Information:       "",
 		Definitions: []string{
-			"ålderdom.  &quot; tiill aller da[gha] &quot; MD (S) 242 . oppa sina aldher dagha  Lg 3: 650 .",
+			"ålderdom.  \" tiill aller da[gha] \" MD (S) 242 . oppa sina aldher dagha  Lg 3: 650 .",
 		},
 		AlternativeForms: []string{
 			"aller- )",


### PR DESCRIPTION
Changes in source
- New "Information" tag for additional grammar info
- Multiple parts of speech -> previously string, now []string
- Quotes in definitions use different encoding insteat of "quot" style escapes

New source provided by https://github.com/stscoundrel/old-swedish-dictionary-builder